### PR TITLE
feat: 支持TELEGRAM_ID以逗号分隔分发多个

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Location: Workers & Pages - your_work_name - Settings - Variables
 
 | KEY                    | Description                                                  |
 | :--------------------- | :----------------------------------------------------------- |
-| TELEGRAM_ID            | The Chat ID of the destination to sent by the Bot (such as your own Telegram account ID), can be obtained through the bot's `/id` command, which is generally a series of numbers, GROUP's start with -100. |
+| TELEGRAM_ID            | The Chat ID of the destination to sent by the Bot (such as your own Telegram account ID), can be obtained through the bot's `/id` command, which is generally a series of numbers, GROUP's start with -100. Multiple IDs separated by English commas |
 | TELEGRAM_TOKEN         | Telegram Bot Token e.g., `7123456780:AAjkLAbvSgDdfsDdfsaSK0` |
 | DOMAIN                 | Workers domain name, e.g., `project_name.user_name.workers.dev` |
 | FORWARD_LIST           | Backup emails, can be forwarded to your own email for backup, leave blank if not forwarding, multiple values can be separated by `,` |

--- a/doc/README_CN.md
+++ b/doc/README_CN.md
@@ -61,7 +61,7 @@ mail2telegram
 
 | KEY                    | 描述                                                         |
 | :--------------------- | ------------------------------------------------------------ |
-| TELEGRAM_ID            | Bot发送目的地的Chat ID（比如你自己Telegram账号的ID），可以通过bot的`/id`指令获取, 一般为一串数字，群组以-100开头 |
+| TELEGRAM_ID            | Bot发送目的地的Chat ID（比如你自己Telegram账号的ID），可以通过bot的`/id`指令获取, 一般为一串数字，群组以-100开头, 多个ID以英文逗号分隔 |
 | TELEGRAM_TOKEN         | Telegram Bot Token 例如：`7123456780:AAjkLAbvSgDdfsDdfsaSK0` |
 | DOMAIN                 | Workers的域名, 例如: `project_name.user_name.workers.dev`    |
 | FORWARD_LIST           | 备份邮件，可以转发到自己的邮箱备份, 留空则不转发，可以填入多个使用`,`分隔 |


### PR DESCRIPTION
缘由：在需要监听邮件派发多个telegram_id时，缺失该功能

PR: TELEGRAM_ID 以英文逗号分隔进行多个 ID 支持