### PR TITLE
fix: error BUTTON_TYPE_INVALID in group

### DIFF
--- a/src/telegram/telegram.ts
+++ b/src/telegram/telegram.ts
@@ -25,7 +25,10 @@ function handleOpenTMACommand(mode: string, text: string | null, env: Environmen
         const params: Telegram.SendMessageParams = {
             chat_id: msg.chat.id,
             text: text || tmaModeDescription[mode] || 'Address Manager',
-            reply_markup: {
+        };
+        
+        if (msg.chat.type === 'private') {
+            params.reply_markup = {
                 inline_keyboard: [
                     [
                         {
@@ -37,7 +40,8 @@ function handleOpenTMACommand(mode: string, text: string | null, env: Environmen
                     ],
                 ],
             },
-        };
+        }
+
         return await createTelegramBotAPI(TELEGRAM_TOKEN).sendMessage(params);
     };
 }


### PR DESCRIPTION
Hi, I found a problem when send message to a group, it fails. It is occurred because Telegram has different rules for inline keyboard buttons in groups vs private chats. Web apps buttons are not supported in groups.


From params: 
```
{
   "chat_id":-100xxx,
   "text":"Your chat ID is -100xxx",
   "reply_markup":{
      "inline_keyboard":[
         [
            {
               "text":"Open Manager",
               "web_app":{
                  "url":"https://xxxx/tma?mode="
               }
            }
         ]
      ]
   }
}
```

I receive error:
```
{
   "ok":false,
   "error_code":400,
   "description":"Bad Request: BUTTON_TYPE_INVALID"
}
```
